### PR TITLE
fix(nix): bump version and force use of python 3.12 to fix mpv gpu is…

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753345091,
-        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
+        "lastModified": 1756386758,
+        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
+        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "Viu Project Flake";
 
   inputs = {
-    # The nixpkgs unstable latest commit breaks the plyer python package
-    nixpkgs.url = "github:nixos/nixpkgs/3ff0e34b1383648053bba8ed03f201d3466f90c9";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -17,21 +16,21 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        inherit (pkgs) lib python3Packages;
+        inherit (pkgs) lib python312Packages;
 
         version = "3.1.0";
       in
       {
-        packages.default = python3Packages.buildPythonApplication {
+        packages.default = python312Packages.buildPythonApplication {
           pname = "viu";
           inherit version;
           pyproject = true;
 
           src = self;
 
-          build-system = with python3Packages; [ hatchling ];
+          build-system = with python312Packages; [ hatchling ];
 
-          dependencies = with python3Packages; [
+          dependencies = with python312Packages; [
             click
             inquirerpy
             requests


### PR DESCRIPTION
In NixOs (nixos-unstable branch) using the provided flake I was having issues that MPV was not running under wayland and was not picking up my gpu causing the video output to have lag spikes (possible due to using the cpu for rendering? not sure). Updating the nixpkgs version used fixed this, I also forced the use of python3.12 in the flake to prevent the mentioned build failure due to plyer.

Just for reference some output screenshots of the metioned error:

Before thes changes:
<img width="1909" height="1044" alt="image" src="https://github.com/user-attachments/assets/6bb7c713-99b7-4ee4-9a52-e01522c469e0" />

After the changes:
<img width="1910" height="1045" alt="image" src="https://github.com/user-attachments/assets/2ca617df-0ee4-49cb-a951-962736309991" />
