### PR TITLE
Fix #148 issue: Animepahe provider not working.

### DIFF
--- a/viu_media/libs/provider/anime/animepahe/constants.py
+++ b/viu_media/libs/provider/anime/animepahe/constants.py
@@ -1,6 +1,6 @@
 import re
 
-ANIMEPAHE = "animepahe.ru"
+ANIMEPAHE = "animepahe.si"
 ANIMEPAHE_BASE = f"https://{ANIMEPAHE}"
 ANIMEPAHE_ENDPOINT = f"{ANIMEPAHE_BASE}/api"
 
@@ -25,7 +25,7 @@ SERVER_HEADERS = {
     "Accept-Encoding": "Utf-8",
     "DNT": "1",
     "Connection": "keep-alive",
-    "Referer": "https://animepahe.ru/",
+    "Referer": "https://animepahe.si/",
     "Upgrade-Insecure-Requests": "1",
     "Sec-Fetch-Dest": "iframe",
     "Sec-Fetch-Mode": "navigate",


### PR DESCRIPTION
I tried this on my machine and it seems to fixed the issue.

My speculation is the `.ru` domain cause the server to returns some redirect code (could be one of 301, 307, 308) and viu misinterpret it as the server failed to respond?

commit:
- change: animepahe provider domain from '.ru' to '.si'

@Benexl review pls